### PR TITLE
Update OrdersProcessor.php

### DIFF
--- a/assets/plugins/commerce/src/Processors/OrdersProcessor.php
+++ b/assets/plugins/commerce/src/Processors/OrdersProcessor.php
@@ -333,7 +333,7 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
         return true;
     }
 
-    public function updateOrder($order_id, $data = [], $force = false)
+    public function updateOrder($order_id, $data = [], $invokeEvents = true)
     {
         $params = [
             'order_id' => $order_id,
@@ -345,7 +345,7 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
             }
         }
         
-        if (!$force) {
+        if ($invokeEvents !== false) {
             $this->modx->invokeEvent('OnBeforeOrderSaving', $params);    
         }
         
@@ -448,7 +448,7 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
         
         $params['mode'] = 'upd';
         
-        if (!$force) {
+        if ($invokeEvents !== false) {
             $this->modx->invokeEvent('OnOrderSaved', $params);
         }
 

--- a/assets/plugins/commerce/src/Processors/OrdersProcessor.php
+++ b/assets/plugins/commerce/src/Processors/OrdersProcessor.php
@@ -333,7 +333,7 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
         return true;
     }
 
-    public function updateOrder($order_id, $data = [])
+    public function updateOrder($order_id, $data = [], $force = false)
     {
         $params = [
             'order_id' => $order_id,
@@ -344,9 +344,11 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
                 $params[$field] = &$data[$field];
             }
         }
-
-        $this->modx->invokeEvent('OnBeforeOrderSaving', $params);
-
+        
+        if (!$force) {
+            $this->modx->invokeEvent('OnBeforeOrderSaving', $params);    
+        }
+        
         $db = $this->modx->db;
 
         try {
@@ -445,7 +447,10 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
         }
         
         $params['mode'] = 'upd';
-        $this->modx->invokeEvent('OnOrderSaved', $params);
+        
+        if (!$force) {
+            $this->modx->invokeEvent('OnOrderSaved', $params);
+        }
 
         return true;
     }


### PR DESCRIPTION
Иногда требуется заапдейтить ордер где-то в событиях плагинов без ивентов и собственных костылей. С ивентами может зациклиться и рухнуть в бесконечном цикле.